### PR TITLE
right-stick zoom

### DIFF
--- a/Assets/TurnrootFramework/Gameplay/GameplayInputSettings.cs
+++ b/Assets/TurnrootFramework/Gameplay/GameplayInputSettings.cs
@@ -31,6 +31,7 @@ namespace Turnroot.GameSettings
         public InputActionReference RotateCamera;
         public InputActionReference Start;
         public InputActionReference ToggleDetails;
+        public InputActionReference RightStickClick;
 
         [Header("Hold Repeat"), HorizontalLine(color: EColor.Green)]
         [Tooltip("Seconds before held navigation begins repeating.")]

--- a/Assets/TurnrootFramework/Gameplay/NonCombatScenes/Hub/HubManager/HubManager.cs
+++ b/Assets/TurnrootFramework/Gameplay/NonCombatScenes/Hub/HubManager/HubManager.cs
@@ -422,9 +422,21 @@ namespace Turnroot.Gameplay.NonCombatScenes.Hub
 
             CacheSpawnPointHeights();
 
+            if (LocationChoices == null || LocationChoices.Length != subLocations.Length)
+            {
+                $"LocationChoices has {LocationChoices?.Length ?? 0} entries but subLocations has {subLocations.Length}. They must be the same length and in the same order. Check the HubManager inspector.".LogWarning();
+            }
+
             for (int i = 0; i < subLocations.Length; i++)
             {
                 subLocations[i].Initialize(_brain);
+
+                if (LocationChoices == null || i >= LocationChoices.Length)
+                {
+                    $"No LocationChoices entry at index {i} for sublocation '{subLocations[i].LocationName}'. Add a UiChoice for it in the HubManager inspector.".LogWarning();
+                    continue;
+                }
+
                 LocationChoices[i].CanBeSelected = subLocations[i].CanBeVisitedToday();
             }
 

--- a/Assets/TurnrootFramework/Gameplay/NonCombatScenes/Hub/HubSubInput.cs
+++ b/Assets/TurnrootFramework/Gameplay/NonCombatScenes/Hub/HubSubInput.cs
@@ -1,3 +1,4 @@
+using Turnroot.UI;
 using Turnroot.Utilities;
 using Turnroot.Utilities.AbstractScripts;
 using UnityEngine;
@@ -10,9 +11,7 @@ namespace Turnroot.Gameplay.NonCombatScenes.Hub
     public class HubSubInput : MonoBehaviour
     {
         // absolute degree limits from the default hub sublocation base orientation; use positive values.
-        // World-space tilt is clamped to [default - left,right] and [default - up,down], even when returning from POI.
-        public float MaxTiltLeft;
-        public float MaxTiltRight;
+        // World-space tilt is clamped to [default - up,down], even when returning from POI.
         public float MaxTiltUp;
         public float MaxTiltDown;
 
@@ -38,6 +37,7 @@ namespace Turnroot.Gameplay.NonCombatScenes.Hub
 
         public LayerMask zoomLayerMask;
         public float normalFov = 60f;
+        public float zoomedFov = 30f;
 
         public UIFade FocusOverlayFade;
 
@@ -46,10 +46,9 @@ namespace Turnroot.Gameplay.NonCombatScenes.Hub
         )]
         public float zoomCastRadius = 0.25f;
         private bool _isPoiActive;
+        private bool _isZoomed;
 
         // Tilt-limit magnitudes cached from inspector values on each SetLookEnabled(true).
-        private float _cachedLeftLimit;
-        private float _cachedRightLimit;
         private float _cachedUpLimit;
         private float _cachedDownLimit;
 
@@ -104,10 +103,42 @@ namespace Turnroot.Gameplay.NonCombatScenes.Hub
             {
                 _hasBaseRotation = false;
                 _pitchOffset = _yawOffset = 0f;
-                _cachedLeftLimit = Mathf.Abs(MaxTiltLeft);
-                _cachedRightLimit = Mathf.Abs(MaxTiltRight);
                 _cachedUpLimit = Mathf.Abs(MaxTiltUp);
                 _cachedDownLimit = Mathf.Abs(MaxTiltDown);
+                if (UiChoice.RightStickClickAction != null)
+                {
+                    UiChoice.RightStickClickAction.performed += HandleZoomToggle;
+                }
+            }
+            else
+            {
+                if (UiChoice.RightStickClickAction != null)
+                {
+                    UiChoice.RightStickClickAction.performed -= HandleZoomToggle;
+                }
+                _isZoomed = false;
+                if (hubCamera != null)
+                {
+                    hubCamera.fieldOfView = normalFov;
+                }
+                FocusOverlayFade?.Hide();
+            }
+        }
+
+        private void HandleZoomToggle(InputAction.CallbackContext _)
+        {
+            _isZoomed = !_isZoomed;
+            if (hubCamera != null)
+            {
+                hubCamera.fieldOfView = _isZoomed ? zoomedFov : normalFov;
+            }
+            if (_isZoomed)
+            {
+                FocusOverlayFade?.Show();
+            }
+            else
+            {
+                FocusOverlayFade?.Hide();
             }
         }
 
@@ -151,13 +182,6 @@ namespace Turnroot.Gameplay.NonCombatScenes.Hub
             _yawOffset += h * lookStep * Time.deltaTime;
             _pitchOffset -= v * lookStep * Time.deltaTime;
 
-            // Clamp the scalar offsets directly. This is always correct: _yawOffset and
-            // _pitchOffset are degree-of-deviation scalars (never exceeding ±180), so
-            // Mathf.Clamp with scalar limits needs no wrapping logic. The previous world-space
-            // approach (ClampAngleToRange) introduced a wrapped-interval bug: going to max-left
-            // then max-right caused the wrapped "angle >= min || angle <= max" check to pass for
-            // all angles near the ±180 boundary, disabling clamping for the rest of the session.
-            _yawOffset = Mathf.Clamp(_yawOffset, -_cachedLeftLimit, _cachedRightLimit);
             _pitchOffset = Mathf.Clamp(_pitchOffset, -_cachedUpLimit, _cachedDownLimit);
 
             Vector3 targetRotation = new Vector3(
@@ -269,34 +293,24 @@ namespace Turnroot.Gameplay.NonCombatScenes.Hub
         {
             Vector2 result = Vector2.zero;
 
-            if (Keyboard.current != null)
+            if (UiChoice.NavigateLeftAction?.IsPressed() == true)
             {
-                if (Keyboard.current.leftArrowKey.isPressed || Keyboard.current.aKey.isPressed)
-                {
-                    result.x -= 1;
-                }
-
-                if (Keyboard.current.rightArrowKey.isPressed || Keyboard.current.dKey.isPressed)
-                {
-                    result.x += 1;
-                }
-
-                if (Keyboard.current.upArrowKey.isPressed || Keyboard.current.wKey.isPressed)
-                {
-                    result.y += 1;
-                }
-
-                if (Keyboard.current.downArrowKey.isPressed || Keyboard.current.sKey.isPressed)
-                {
-                    result.y -= 1;
-                }
+                result.x -= 1;
             }
 
-            if (Gamepad.current != null)
+            if (UiChoice.NavigateRightAction?.IsPressed() == true)
             {
-                result += Gamepad.current.leftStick.ReadValue();
-                result += Gamepad.current.rightStick.ReadValue();
-                result += Gamepad.current.dpad.ReadValue();
+                result.x += 1;
+            }
+
+            if (UiChoice.NavigateUpAction?.IsPressed() == true)
+            {
+                result.y += 1;
+            }
+
+            if (UiChoice.NavigateDownAction?.IsPressed() == true)
+            {
+                result.y -= 1;
             }
 
             return result;

--- a/Assets/TurnrootFramework/UI/Components/Input/UIInputActionBootstrap.cs
+++ b/Assets/TurnrootFramework/UI/Components/Input/UIInputActionBootstrap.cs
@@ -43,7 +43,8 @@ namespace Turnroot.UI
                 s.Menu,
                 s.RotateCamera,
                 s.Start,
-                s.ToggleDetails
+                s.ToggleDetails,
+                s.RightStickClick
             );
 
             // Enable everything immediately so all consumers can listen to all actions.
@@ -78,6 +79,7 @@ namespace Turnroot.UI
             TryEnable(UIInputActionDefaults.RotateCamera);
             TryEnable(UIInputActionDefaults.Start);
             TryEnable(UIInputActionDefaults.ToggleDetails);
+            TryEnable(UIInputActionDefaults.RightStickClick);
         }
     }
 }

--- a/Assets/TurnrootFramework/UI/Components/Input/UIInputActionDefaults.cs
+++ b/Assets/TurnrootFramework/UI/Components/Input/UIInputActionDefaults.cs
@@ -49,6 +49,7 @@ namespace Turnroot.UI
         public static InputAction ToggleDetails;
         public static InputAction ScrollLeft;
         public static InputAction ScrollRight;
+        public static InputAction RightStickClick;
 
         private static bool _enforceActionsAlwaysEnabled;
 
@@ -67,6 +68,7 @@ namespace Turnroot.UI
             InputActionReference menu,
             InputActionReference rotateCamera,
             InputActionReference start,
+            InputActionReference rightStickClick,
             InputActionReference toggleDetails
         )
         {
@@ -76,6 +78,7 @@ namespace Turnroot.UI
             NavigateDown = navigateDown?.action;
             NavigateLeft = navigateLeft?.action;
             NavigateRight = navigateRight?.action;
+            RightStickClick = rightStickClick?.action;
 
             Navigate = navigate?.action;
             Confirm = confirm?.action;
@@ -136,6 +139,7 @@ namespace Turnroot.UI
             TryEnable(ToggleDetails);
             TryEnable(ScrollLeft);
             TryEnable(ScrollRight);
+            TryEnable(RightStickClick);
         }
 
         private static void EnsureSharedActionsStayEnabled()
@@ -188,7 +192,8 @@ namespace Turnroot.UI
                 || action == Start
                 || action == ToggleDetails
                 || action == ScrollLeft
-                || action == ScrollRight;
+                || action == ScrollRight
+                || action == RightStickClick;
         }
     }
 }

--- a/Assets/TurnrootFramework/UI/Components/SimpleChoiceSelection/UiChoice.cs
+++ b/Assets/TurnrootFramework/UI/Components/SimpleChoiceSelection/UiChoice.cs
@@ -21,6 +21,7 @@ namespace Turnroot.UI
         public static InputAction NavigateLeftAction => UIInputActionDefaults.NavigateLeft;
         public static InputAction NavigateRightAction => UIInputActionDefaults.NavigateRight;
         public static InputAction StartAction => UIInputActionDefaults.Start;
+        public static InputAction RightStickClickAction => UIInputActionDefaults.RightStickClick;
 
         public static InputAction ScrollLeftAction => UIInputActionDefaults.ScrollLeft;
         public static InputAction ScrollRightAction => UIInputActionDefaults.ScrollRight;

--- a/Assets/TurnrootFramework/package.json
+++ b/Assets/TurnrootFramework/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.turnroot.framework",
-	"version": "0.1.680",
+	"version": "0.1.682",
 	"displayName": "Turnroot Framework",
 	"description": "A turn-based RPG framework for Unity.",
 	"author": {


### PR DESCRIPTION
Introduce a RightStickClick input action and wire it through GameplayInputSettings, UIInputActionDefaults, and the UI bootstrap so consumers can listen for right-stick clicks. Update UiChoice to expose the new action. In HubSubInput add zoom state (zoomedFov, _isZoomed), subscribe/unsubscribe to RightStickClick to toggle zoom and show/hide the focus overlay, and simplify input polling to use UiChoice Navigate actions instead of raw Keyboard/Gamepad queries. Remove legacy left/right tilt caching and adjust pitch-only clamping. In HubManager add warnings when LocationChoices is missing or length-mismatched and when individual entries are absent, preventing null indexing and improving inspector feedback.